### PR TITLE
Added the AvaTax spl_autoload to the cron (observer_processQueue) which was not calling it correctly.

### DIFF
--- a/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Config.php
+++ b/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Config.php
@@ -53,6 +53,8 @@ class OnePica_AvaTax_Model_Service_Avatax_Config extends OnePica_AvaTax_Model_Se
      */
     public function init($storeId)
     {
+        Mage::getSingleton('avatax/observer_loadAvaTaxExternalLib')->loadAvaTaxExternalLib();
+        
         if (null === $this->_config) {
             $cfgValues = array(
                 'url'     => Mage::helper('avatax/config')->getServiceUrl($storeId),


### PR DESCRIPTION
the cron job was failing
n98-magerun sys:cron:run avatax_processqueue

Run OnePica_AvaTax_Model_Observer_ProcessQueue::execute PHP Fatal error:  Uncaught Error: Class 'ATConfig' not found in /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Config.php:73
Stack trace:
#0 /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Service/Abstract.php(67): OnePica_AvaTax_Model_Service_Avatax_Config->init('0')
#1 /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Service/Avatax.php(46): OnePica_AvaTax_Model_Service_Abstract->setStoreId('0')
#2 /var/www/htdocs/app/code/core/Mage/Core/Model/Config.php(1357): OnePica_AvaTax_Model_Service_Avatax->__construct(Array)
#3 /var/www/htdocs/app/Mage.php(466): Mage_Core_Model_Config->getModelInstance('avatax/service_...', Array)
#4 /var/www/htdocs/app/Mage.php(480): Mage::getModel('avatax/service_...', Array)
#5 /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Factory.php(75): Mage::getSingleton('avatax/service_...', Array)
#6 /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Service.php(48): OnePica_AvaTax_Model_Factory->getSingleton('avatax/service_...', Array)
#7 /var/www/htdocs in /var/www/htdocs/app/code/community/OnePica/AvaTax/Model/Service/Avatax/Config.php on line 73

